### PR TITLE
Add integration test for external logger

### DIFF
--- a/common/network.js
+++ b/common/network.js
@@ -2,27 +2,6 @@ var fetch = require("node-fetch");
 
 module.exports = {
   httpFetch: function(dest, opts) {
-    if (!opts) {
-      return fetch(dest);
-    }
-
-    setHeaders();
     return fetch(dest, opts);
-
-    function setHeaders() {
-      var headerArray = opts.headers,
-      headers;
-
-      if (!headerArray) {return;}
-
-      headers = new Headers();
-
-      headerArray.forEach(function(header) {
-        var nameValue = header.split(":");
-        headers.append(nameValue[0], nameValue[1].replace(" ", ""));
-      });
-
-      opts.headers = headers;
-    }
   }
 };

--- a/logger/external-logger-bigquery.js
+++ b/logger/external-logger-bigquery.js
@@ -40,8 +40,9 @@ module.exports = (network)=>{
     if (new Date() - EXTERNAL_LOGGER_REFRESH_DATE < 3580000) {
       return Promise.resolve(EXTERNAL_LOGGER_TOKEN);
     }
-    return network.fetch(EXTERNAL_LOGGER_REFRESH_URL, {method: "POST"})
-    .then(resp=>{return resp.JSON();})
+
+    return network.httpFetch(EXTERNAL_LOGGER_REFRESH_URL, {method: "POST"})
+    .then(resp=>{return resp.json();})
     .then(json=>{return {token: json.access_token, refreshedAt: new Date()};});
   }
 
@@ -59,10 +60,10 @@ module.exports = (network)=>{
 
         EXTERNAL_LOGGER_REFRESH_DATE = refreshData.refreshedAt || EXTERNAL_LOGGER_REFRESH_DATE;
         EXTERNAL_LOGGER_TOKEN = refreshData.token || EXTERNAL_LOGGER_TOKEN;
-        headers = [
-          "Content-Type: application/json",
-          "Authorization: Bearer " + EXTERNAL_LOGGER_TOKEN
-        ];
+        headers = {
+          "Content-Type": "application/json",
+          "Authorization": "Bearer " + EXTERNAL_LOGGER_TOKEN
+        };
 
         insertData.rows[0].insertId = Math.random().toString(36).substr(2).toUpperCase();
         insertData.rows[0].json.event = eventName;
@@ -71,7 +72,7 @@ module.exports = (network)=>{
         if (eventDetails) {insertData.rows[0].json.event_details = eventDetails;}
         insertData.rows[0].json.ts = new Date().toISOString();
         insertData = JSON.stringify(insertData);
-        return network.fetch(serviceUrl, {
+        return network.httpFetch(serviceUrl, {
           method: "POST",
           headers,
           body: insertData

--- a/test/integration/external-logger-bigquery.js
+++ b/test/integration/external-logger-bigquery.js
@@ -1,10 +1,18 @@
 "use strict";
 var assert = require("assert"),
-logger = require("../../logger/external-logger-bigquery.js")
+extlogger = require("../../logger/external-logger-bigquery.js")
 (require("../../common/network.js"));
 
+global.log = require("../../logger/logger.js")();
+
 describe("external logger bigquery", function() {
-  xit("logs to bigquery", function() {
-    assert.ok(logger);
+  it("logs to bigquery", function() {
+    return extlogger.log("testEvent", "testId", "testVersion", "testDetails")
+    .then(resp=>{
+      return resp.json();
+    })
+    .then(json=>{
+      assert.ok(json.kind === "bigquery#tableDataInsertAllResponse");
+    });
   });
 });

--- a/test/unit/external-logger-bigquery.js
+++ b/test/unit/external-logger-bigquery.js
@@ -10,16 +10,16 @@ describe("external logger bigquery", function() {
 
   it("makes the post call", function() {
     var stub = mock.stub()
-    .resolveWith({JSON() {return Promise.resolve({access_token: "test-token"});}})
+    .resolveWith({json() {return Promise.resolve({access_token: "test-token"});}})
     .resolveWith({});
-    extlogger = require("../../logger/external-logger-bigquery.js")({fetch: stub});
+    extlogger = require("../../logger/external-logger-bigquery.js")
+    ({httpFetch: stub});
 
     return extlogger.log("testEvent", "testId", "testVersion", "testDetails")
     .then(()=>{
-      var authHeader = "Authorization: Bearer test-token";
       assert.ok(/datasets\/Installer_Events/.test(stub.lastCall.args[0]));
       assert.ok(/tables\/events[0-9]{8}/.test(stub.lastCall.args[0]));
-      assert.ok(stub.lastCall.args[1].headers.indexOf(authHeader) !== -1);
+      assert.ok(stub.lastCall.args[1].headers.Authorization === "Bearer test-token");
       assert.ok(JSON.parse(stub.lastCall.args[1].body).rows[0].json.event === "testEvent");
     });
   });


### PR DESCRIPTION
node-fetch can handle a native js object for the headers so network.js doesn't need a custom setHeaders handler.