### PR TITLE
Use a temporary display id for logging new display

### DIFF
--- a/common/config.js
+++ b/common/config.js
@@ -65,8 +65,13 @@ function getDisplaySettingsFileName() {
 }
 
 function getDisplaySettingsSync() {
-  var textFileString = platform.readTextFileSync(getDisplaySettingsFileName());
-  if (!textFileString || textFileString.length === 0) {return {};}
+  var tempDisplayId = Math.random() + "",
+  textFileString = platform.readTextFileSync(getDisplaySettingsFileName());
+  if (!textFileString) {textFileString = "";}
+  if (textFileString.indexOf("displayid") < 0) {
+    textFileString += "\ntempdisplayid=" + tempDisplayId;
+  }
+
   return parsePropertyList(textFileString);
 }
 

--- a/logger/bigquery/external-logger-bigquery.js
+++ b/logger/bigquery/external-logger-bigquery.js
@@ -45,6 +45,7 @@ module.exports = (network, platform)=>{
 
       return mod.refreshToken(nowDate).then(()=>{
         var insertData = JSON.parse(JSON.stringify(config.insertSchema)),
+        row = insertData.rows[0],
         serviceUrl,
         headers; 
 
@@ -56,13 +57,13 @@ module.exports = (network, platform)=>{
           "Authorization": "Bearer " + token
         };
 
-        insertData.rows[0].insertId = Math.random().toString(36).substr(2).toUpperCase();
-        insertData.rows[0].json.event = eventName;
-        insertData.rows[0].json.display_id = displaySettings.displayid;
-        insertData.rows[0].json.installer_version = installerVersion;
-        insertData.rows[0].json.os = os;
-        if (eventDetails) {insertData.rows[0].json.event_details = eventDetails;}
-        insertData.rows[0].json.ts = nowDate.toISOString();
+        row.insertId = Math.random().toString(36).substr(2).toUpperCase();
+        row.json.event = eventName;
+        row.json.display_id = displaySettings.displayid || displaySettings.tempdisplayid;
+        row.json.installer_version = installerVersion;
+        row.json.os = os;
+        if (eventDetails) {row.json.event_details = eventDetails;}
+        row.json.ts = nowDate.toISOString();
         insertData = JSON.stringify(insertData);
         return network.httpFetch(serviceUrl, {
           method: "POST",

--- a/main.js
+++ b/main.js
@@ -15,6 +15,8 @@ log.setDisplaySettings
 global.messages = require("./ui/messages.json"),
 
 log.external("started");
+log.debug("Electron " + process.versions.electron)
+log.debug("Chromium " + process.versions.chrome)
 
 app.on("window-all-closed", ()=>{
   log.debug("All windows closed. quitting...");

--- a/test/unit/common/config.js
+++ b/test/unit/common/config.js
@@ -125,6 +125,26 @@ describe("config", ()=>{
     assert.equal(settings.option1, "value1");
   });
 
+  it("synchronously returns temporary display id if real id doesn't exist", ()=>{
+    mock(platform, "readTextFileSync").returnWith("");
+
+    var settings = config.getDisplaySettingsSync();
+
+    assert(platform.readTextFileSync.called);
+    assert.equal(settings.displayid, undefined);
+    assert.equal(settings.tempdisplayid.substring(0, 2), "0.");
+  });
+
+  it("synchronously only returns real display id if it exists", ()=>{
+    mock(platform, "readTextFileSync").returnWith("displayid=A2F9");
+
+    var settings = config.getDisplaySettingsSync();
+
+    assert(platform.readTextFileSync.called);
+    assert.equal(settings.displayid, "A2F9");
+    assert.equal(settings.tempdisplayid, undefined);
+  });
+
   it("synchronously returns empty display settings on load failure", ()=>{
     mock(platform, "readTextFileSync").returnWith("");
 

--- a/test/unit/external-logger-bigquery.js
+++ b/test/unit/external-logger-bigquery.js
@@ -55,6 +55,24 @@ describe("external logger bigquery", function() {
     });
   });
 
+  it("logs using temp display id if no real display id set up", function() {
+    extlogger.setDisplaySettings({tempdisplayid: "temp id"});
+    return extlogger.log("testEvent")
+    .then(()=>{
+      var calledWithId = JSON.parse(fetchStub.lastCall.args[1].body).rows[0].json.display_id;
+      assert.equal(calledWithId, "temp id");
+    });
+  });
+
+  it("logs using real display id if it exists", function() {
+    extlogger.setDisplaySettings({displayid: "real id"});
+    return extlogger.log("testEvent")
+    .then(()=>{
+      var calledWithId = JSON.parse(fetchStub.lastCall.args[1].body).rows[0].json.display_id;
+      assert.equal(calledWithId, "real id");
+    });
+  });
+
   it("doesn't refresh token if called recently", function() {
     return extlogger.log("testEvent", "testDetails")
     .then(()=>{


### PR DESCRIPTION
Use a simple Math.random() "display id" on new installs.  That way the logging can keep track of log data from the same installer run.