### PR TITLE
Build on master and provide artifacts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,15 @@ deployment:
     branch: /(feature|fix|chore).*/
     commands:
       - node build.js
+      - cp builds/*.exe $CIRCLE_ARTIFACTS
+      - cp builds/*.sh $CIRCLE_ARTIFACTS
+
+  production:
+    branch: master
+    commands:
+      - node build.js
+      - cp builds/*.exe $CIRCLE_ARTIFACTS
+      - cp builds/*.sh $CIRCLE_ARTIFACTS
 
 #Update version.json with a new version number
 #node build


### PR DESCRIPTION
@fjvallarino This copies the builds to circle ci's artifacts server.  This way we don't have to upload to GCS to test out changes.  