### PR TITLE
Use mkdirp to ensure paths exist for file writes

### DIFF
--- a/common/platform.js
+++ b/common/platform.js
@@ -1,5 +1,6 @@
 var childProcess = require("child_process"),
 path = require("path"),
+mkdirp = require("mkdirp"),
 os = require("os"),
 fs = require(process.versions.electron ? "original-fs" : "fs"),
 ncp = require("ncp"),
@@ -109,17 +110,29 @@ module.exports = {
 
     return stringContents;
   },
-  writeTextFile(path, data) {
-    log.debug("writing " + path);
+  writeTextFile(filePath, data) {
+    log.debug("writing " + filePath);
     return new Promise((resolve, reject)=>{
-      fs.writeFile(path, data, "utf8", function (err) {
-        if(!err) {
+      mkdirp(path.dirname(filePath), (err)=>{
+        if (!err) {
           resolve();
-        }
-        else {
+        } else {
           log.error("Error writing file", messages.fileWriteError);
           reject({ message: "Error writing file", error: err });
         }
+      });
+    })
+    .then(()=>{
+      return new Promise((resolve, reject)=>{
+        fs.writeFile(filePath, data, "utf8", function (err) {
+          if(!err) {
+            resolve();
+          }
+          else {
+            log.error("Error writing file", messages.fileWriteError);
+            reject({ message: "Error writing file", error: err });
+          }
+        });
       });
     });
   },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "gunzip-maybe": "^1.2.1",
     "http-proxy-agent": "^1.0.0",
+    "mkdirp": "^0.5.1",
     "ncp": "git://github.com/Rise-Vision/ncp.git",
     "node-fetch": "1.3.3",
     "rimraf": "2.4.3",


### PR DESCRIPTION
@RV-Adrian was getting error on file write.  Turns out autostart and rvplayer directories weren't there so the writes failed.  This should ensure that the paths exist before trying to write the file.