### PR TITLE
Stop running components before removing folders

### DIFF
--- a/common/platform.js
+++ b/common/platform.js
@@ -37,6 +37,14 @@ module.exports = {
   getTempDir() {
     return os.tmpdir();
   },
+  getCwd() {
+    return __dirname;
+  },
+  isDevMode() {
+    var currPath = module.exports.getCwd().split(path.sep);
+
+    return currPath.length < 2 || currPath[currPath.length - 2] !== "resources";
+  },
   getJavaExecutablePath() {
     if (module.exports.isWindows()) {
       return path.join(module.exports.getInstallDir(), "JRE", "bin", "java.exe");
@@ -112,6 +120,22 @@ module.exports = {
         rej(err);
       });
     });
+  },
+  killJava() {
+    if(module.exports.isWindows()) {
+      return module.exports.spawn("taskkill /f /im javaw.exe");
+    }
+    else {
+      return module.exports.spawn("pkill -f " + module.exports.getJavaExecutablePath() + "\n");
+    }
+  },
+  killChromium() {
+    if(module.exports.isWindows()) {
+      return module.exports.spawn("taskkill /f /im chrome.exe");
+    }
+    else {
+      return module.exports.spawn("pkill -f " + path.join(module.exports.getInstallDir(), "chrome-linux") + "\n");
+    }
   },
   readTextFile(path) {
     return new Promise((resolve, reject)=>{

--- a/installer.js
+++ b/installer.js
@@ -42,6 +42,21 @@ module.exports = {
 
           return downloader.extractComponents(changedComponents);
         })
+        .then(()={
+          log.all("stopping cache", changedNames, "52%");
+          return launcher.stopCache();
+        })
+        .then(()={
+          log.all("stopping player", changedNames, "55%");
+          return launcher.stopPlayer();
+        })
+        .then(()={
+          log.all("stopping viewer", changedNames, "58%");
+          return launcher.stopViewer();
+        })
+        .then(()=>{
+          return platform.waitForMillis(2500);
+        })
         .then(()=>{
           log.all("removing previous versions", changedNames, "60%");
 

--- a/installer.js
+++ b/installer.js
@@ -42,17 +42,13 @@ module.exports = {
 
           return downloader.extractComponents(changedComponents);
         })
-        .then(()={
-          log.all("stopping cache", changedNames, "52%");
-          return launcher.stopCache();
+        .then(()=>{
+          log.all("stopping player and cache", changedNames, "52%");
+          return platform.killJava();
         })
-        .then(()={
-          log.all("stopping player", changedNames, "55%");
-          return launcher.stopPlayer();
-        })
-        .then(()={
-          log.all("stopping viewer", changedNames, "58%");
-          return launcher.stopViewer();
+        .then(()=>{
+          log.all("stopping chromium", changedNames, "56%");
+          return platform.killChromium();
         })
         .then(()=>{
           return platform.waitForMillis(2500);
@@ -121,17 +117,14 @@ module.exports = {
     return platform.deleteRecursively(platform.getOldInstallerPath());
   },
   getRunningInstallerDir() {
-    var currPath = module.exports.getCwd().split(path.sep);
-    var pathPrefix = module.exports.getCwd().startsWith(path.sep) ? path.sep : "";
+    var currPath = platform.getCwd().split(path.sep);
+    var pathPrefix = platform.getCwd().startsWith(path.sep) ? path.sep : "";
 
     if(currPath[currPath.length - 2] === "resources" && currPath[currPath.length - 1] === "app") {
       currPath = currPath.slice(0, currPath.length - 2);
     }
 
     return pathPrefix + path.join.apply(null, currPath);
-  },
-  getCwd() {
-    return __dirname;
   },
   getOptions() {
     return options;

--- a/launcher.js
+++ b/launcher.js
@@ -1,12 +1,6 @@
 var platform = require("./common/platform.js"),
 network = require("./common/network.js"),
-config = require("./common/config.js"),
-url = require("url"),
 path = require("path");
-
-function replaceAll(string, search, replace) {
-  return string.split(search).join(replace);
-}
 
 function getJavaPath() {
   if(platform.isWindows()) {
@@ -17,22 +11,8 @@ function getJavaPath() {
   }
 }
 
-function stopCache() {
-  return network.httpFetch("http://localhost:9494/shutdown", { timeout: 500 })
-  .catch((err)=>{
-    return Promise.resolve();
-  });
-}
-
 function startCache() {
   platform.startProcess(getJavaPath(), network.getJavaProxyArgs().concat(["-jar", path.join(platform.getInstallDir(), "RiseCache", "RiseCache.jar")]));
-}
-
-function stopPlayer() {
-  return network.httpFetch("http://localhost:9449/shutdown", { timeout: 500 })
-  .catch((err)=>{
-    return Promise.resolve();
-  });
 }
 
 function startPlayer() {
@@ -40,32 +20,23 @@ function startPlayer() {
 }
 
 module.exports = {
-  replaceAll,
   getJavaPath,
-  stopCache,
   startCache,
-  stopPlayer,
   startPlayer,
   launch() {
-    return module.exports.stopCache()
+    return platform.killJava()
     .then(()=>{
       return platform.waitForMillis(2000);
     })
     .then(()=>{
       log.all("cache start", "", "50%");
       startCache();
-
-      return module.exports.stopPlayer();
-    })
-    .then(()=>{
-      return platform.waitForMillis(2000);
+      return platform.waitForMillis(1000);
     })
     .then(()=>{
       log.all("player start", "", "100%");
-      return startPlayer();
-    })
-    .then(()=>{
-      return platform.waitForMillis(2000);
+      startPlayer();
+      return platform.waitForMillis(1000);
     });
   }
 };

--- a/network-check.js
+++ b/network-check.js
@@ -38,6 +38,8 @@ module.exports = {
   checkSitesWithJava() {
     var command = `${platform.getJavaExecutablePath()} ${network.getJavaProxyArgs().join(" ")} -jar ${path.join(platform.getInstallerDir(), "resources", "app", "java-network-test.jar")} ${siteList.join(" ")}`;
 
+    if(platform.isDevMode()) return Promise.resolve();
+
     return platform.spawn(command)
     .then((retCode)=>{
       if (retCode !== 0) {throw new Error(retCode);}

--- a/test/unit/common/platform.js
+++ b/test/unit/common/platform.js
@@ -63,6 +63,18 @@ describe("platform", ()=>{
     assert(os.tmpdir.called);
   });
 
+  it("validates application is running in devMode", ()=>{
+    mock(platform, "getCwd").returnWith(path.join("test"));
+
+    assert(platform.isDevMode());
+  });  
+
+  it("validates application is not running in devMode", ()=>{
+    mock(platform, "getCwd").returnWith(path.join("test", "resources", "app"));
+
+    assert(!platform.isDevMode());
+  });  
+
   it("waits for 100ms to resolve the promise", ()=>{
     var time0 = new Date().getTime();
 
@@ -79,6 +91,46 @@ describe("platform", ()=>{
     assert(childProcess.spawn.called);
     assert.equal(childProcess.spawn.lastCall.args[0], "ls");
     assert.equal(childProcess.spawn.lastCall.args[2].detached, true);
+  });
+
+  it("kills Java on Windows", ()=>{
+    mock(platform, "isWindows").returnWith(true);
+    mock(platform, "spawn").resolveWith();
+
+    return platform.killJava().then(()=>{
+      assert(platform.spawn.called);
+      assert(platform.spawn.lastCall.args[0].indexOf("javaw.exe") >= 0);
+    });
+  });
+
+  it("kills Java on Linux", ()=>{
+    mock(platform, "isWindows").returnWith(false);
+    mock(platform, "spawn").resolveWith();
+
+    return platform.killJava().then(()=>{
+      assert(platform.spawn.called);
+      assert(platform.spawn.lastCall.args[0].indexOf("pkill") >= 0);
+    });
+  });
+
+  it("kills Chromium on Windows", ()=>{
+    mock(platform, "isWindows").returnWith(true);
+    mock(platform, "spawn").resolveWith();
+
+    return platform.killChromium().then(()=>{
+      assert(platform.spawn.called);
+      assert(platform.spawn.lastCall.args[0].indexOf("chrome.exe") >= 0);
+    });
+  });
+
+  it("kills Chromium on Linux", ()=>{
+    mock(platform, "isWindows").returnWith(false);
+    mock(platform, "spawn").resolveWith();
+
+    return platform.killChromium().then(()=>{
+      assert(platform.spawn.called);
+      assert(platform.spawn.lastCall.args[0].indexOf("chrome-linux") >= 0);
+    });
   });
 
   it("reads a text file", ()=>{

--- a/test/unit/installer.js
+++ b/test/unit/installer.js
@@ -68,7 +68,10 @@ describe("installer", ()=>{
     mock(platform, "execSync").returnWith();
     mock(platform, "onFirstRun").resolveWith();
     mock(platform, "writeTextFile").resolveWith();
-
+    mock(platform, "killJava").resolveWith();
+    mock(platform, "killChromium").resolveWith();
+    mock(platform, "waitForMillis").resolveWith();
+    
     mock(downloader, "downloadComponents").resolveWith();
     mock(downloader, "extractComponents").resolveWith();
     mock(downloader, "installComponent").resolveWith();
@@ -267,7 +270,7 @@ describe("installer", ()=>{
   });
 
   it("gets a valid running installer directory", ()=>{
-    mock(installer, "getCwd").returnWith(path.join("test", "installer"));
+    mock(platform, "getCwd").returnWith(path.join("test", "installer"));
 
     var installerDir = installer.getRunningInstallerDir();
 
@@ -275,7 +278,7 @@ describe("installer", ()=>{
   });
 
   it("gets a valid running installer directory when manually invoking node", ()=>{
-    mock(installer, "getCwd").returnWith(path.join("test", "installer", "resources", "app"));
+    mock(platform, "getCwd").returnWith(path.join("test", "installer", "resources", "app"));
 
     var installerDir = installer.getRunningInstallerDir();
 

--- a/test/unit/launcher.js
+++ b/test/unit/launcher.js
@@ -17,10 +17,6 @@ describe("launcher", ()=>{
     simpleMock.restore();
   });
 
-  it("properly replaces strings", ()=>{
-    assert.equal(launcher.replaceAll("this_is_a_test", "_", " "), "this is a test");
-  });
-
   it("returns the correct Java Path on Windows", ()=>{
     mock(platform, "getInstallDir").returnWith("test");
     mock(platform, "isWindows").returnWith(true);
@@ -83,6 +79,7 @@ describe("launcher", ()=>{
     mock(platform, "getInstallDir").returnWith("test");
     mock(platform, "startProcess").returnWith();
     mock(platform, "waitForMillis").resolveWith();
+    mock(platform, "killJava").resolveWith();
     mock(network, "httpFetch").resolveWith();
 
     return launcher.launch().then(()=>{
@@ -95,6 +92,7 @@ describe("launcher", ()=>{
     mock(platform, "getInstallDir").returnWith("test");
     mock(platform, "startProcess").returnWith();
     mock(platform, "waitForMillis").resolveWith();
+    mock(platform, "killJava").resolveWith();
     mock(network, "httpFetch").rejectWith();
 
     return launcher.launch().then(()=>{

--- a/test/unit/network-check.js
+++ b/test/unit/network-check.js
@@ -47,9 +47,23 @@ describe("network check", ()=>{
     });
   });
 
+  it("does not call spawn on devMode", ()=>{
+    mock(platform, "spawn").resolveWith(0);
+    mock(platform, "isDevMode").returnWith(true);
+    
+    return checker.checkSitesWithJava()
+    .then(()=>{
+      assert(!platform.spawn.called);
+    })
+    .catch(()=>{
+      assert.ok(false);
+    });
+  });
+
   it("checks for java connectivity to sites", ()=>{
     mock(platform, "spawn").resolveWith(0);
-
+    mock(platform, "isDevMode").returnWith(false);
+    
     return checker.checkSitesWithJava()
     .then((retCode)=>{
       assert.ok(platform.spawn.calls[0].args[0].indexOf("java") > 0);
@@ -61,6 +75,7 @@ describe("network check", ()=>{
 
   it("throws on no java connectivity", ()=>{
     mock(platform, "spawn").resolveWith(1);
+    mock(platform, "isDevMode").returnWith(false);
 
     return checker.checkSitesWithJava()
     .then(()=>{


### PR DESCRIPTION
@fjvallarino This is going to fail because stopViewer doesn't exist.  

But I think we should have a general stopAll() that we can call instead of calling 4 different  methods