### PR TITLE
Don't check for googleapis or catch rejections

### DIFF
--- a/installer/network-check.js
+++ b/installer/network-check.js
@@ -7,7 +7,6 @@ siteList = [
   "http://rvashow.appspot.com",
   "http://storage-dot-rvaserver2.appspot.com",
   "https://store.risevision.com",
-  "http://googleapis.com",
   "https://accounts.google.com/ManageAccount",
   "https://talkgadget.google.com",
   "http://s3.amazonaws.com",
@@ -21,18 +20,12 @@ function checkSite(site, retryCount, timeout) {
   .then((res)=>{
     if (res.status < 200 || res.status > 299) {
       log.external("network prereq error", res.status + " - " + site);
-      if (retryCount === 0) { throw new Error("not ok");}
+      if (retryCount === 0) { return Promise.reject("status not ok - " + res.status);}
       return platform.waitForMillis(timeout || 5000)
       .then(checkSite.bind(null, site, retryCount - 1, timeout));
     }
     promisesPct += 9;
     log.all("Checking network connectivity - " + site, "", promisesPct + "%");
-  })
-  .catch((err)=>{
-    log.external("network prereq error", err);
-    if (retryCount === 0) { throw new Error("not ok");}
-    return platform.waitForMillis(timeout || 5000)
-    .then(checkSite.bind(null, site, retryCount - 1, timeout));
   });
 }
 

--- a/test/unit/network-check.js
+++ b/test/unit/network-check.js
@@ -36,14 +36,6 @@ describe("network check", ()=>{
     });
   });
 
-  it("retries on bad connectivity in Electron", ()=>{
-    mock(network, "httpFetch").rejectWith(false);
-    return checker.checkSitesWithElectron(1, 100)
-    .catch(()=>{
-      assert.ok(network.httpFetch.callCount > 9);
-    });
-  });
-
   it("fails on bad response", ()=>{
     mock(network, "httpFetch").resolveWith({ status: 500 });
     return checker.checkSitesWithElectron(0)


### PR DESCRIPTION
@fjvallarino This has to go in for today's release so that googleapis isn't checked.  And the catch was removed because it was catching the throw just above.  @ahmedalsudani fyi