### PR TITLE
Fix: empty response considered yes

### DIFF
--- a/installer/initial-run.sh
+++ b/installer/initial-run.sh
@@ -24,7 +24,7 @@ if [ $? != 0 ]; then
   exit 0
 fi
 
-if [ $REPLY != y ]; then
+if [ "$REPLY" != y ]; then
   exit 1
 fi
 


### PR DESCRIPTION
If a user is prompted to enter 'y' by initial-run, an empty
response will not cause the installation to continue