### PR TITLE
Kill explorer.exe on Windows (except on 7) before starting Player

### DIFF
--- a/installer/ui/controller.js
+++ b/installer/ui/controller.js
@@ -50,5 +50,8 @@ module.exports = {
   },
   startUnattended() {
     mainWindow.webContents.send("start-unattended");
+  },
+  startUnattendedCountdown() {
+    mainWindow.webContents.send("start-unattended-countdown");
   }
 };

--- a/installer/ui/ipc.js
+++ b/installer/ui/ipc.js
@@ -74,6 +74,14 @@ ipc.on("start-unattended", ()=> {
 
   currentSlide.className = "container slide inactive";
   installingSlide.className = "container slide active";
+});
+
+ipc.on("start-unattended-countdown", ()=> {
+  var currentSlide = document.querySelector(".container.slide.active"),
+  unattendedCountdownSlide = document.querySelector("#unattendedCountdown");
+
+  currentSlide.className = "container slide inactive";
+  unattendedCountdownSlide.className = "container slide active";
 
   ipc.send("install-unattended");
 });
@@ -139,4 +147,10 @@ ipc.on("set-progress", (evt, detail)=>{
   message = document.querySelector("#statusLabel");
   bar.style.width = detail.pct;
   message.innerHTML = detail.msg;
+});
+
+ipc.on("set-unattended-countdown", (evt, detail)=>{
+  var message = document.querySelector("#unattendedCountdownLabel");
+  
+  message.innerHTML = detail;
 });

--- a/installer/ui/main.html
+++ b/installer/ui/main.html
@@ -64,6 +64,13 @@
             <label class="css-label" for="startPlayer">Start Player</label>
         </div>
     </div>
+    <!-- Unattended launch countdown -->
+    <div id="unattendedCountdown" class="container slide inactive">
+        <div class="centeredBox textCenter">
+            <h2>Rise Player will start after the countdown finishes</h2>
+            <h3 id="unattendedCountdownLabel">10</h3>
+        </div>
+    </div>
     <div class="footer">
         <button type="button" class="btn btn-default closeInstall" id="cancel">Cancel</button>
         <button type="button" class="btn btn-primary" id="continue">Continue</button>

--- a/main.js
+++ b/main.js
@@ -54,6 +54,12 @@ function isUnattended() {
   });
 }
 
+function isTestingMode() {
+  return process.argv.slice(1).some((arg)=>{
+    return arg.indexOf("testing-mode") > -1;
+  });
+}
+
 app.makeSingleInstance(()=>{
   log.debug("Another instance was started.  Quitting.");
   app.quit();
@@ -105,7 +111,8 @@ app.on("ready", ()=>{
   });
 
   ipc.on("install-unattended", (event)=>{
-    var countDown = 10, timer = null;
+    var countDown = isTestingMode() ? 0 : 10;
+    var timer = null;
 
     ui.disableContinue();
 
@@ -131,7 +138,7 @@ app.on("ready", ()=>{
         countDown--;
         event.sender.send("set-unattended-countdown", countDown);
       }
-    }, 1000);
+    }, isTestingMode() ? 0 : 1000);
   });
 
   ipc.on("launch", ()=>{

--- a/main.js
+++ b/main.js
@@ -135,10 +135,12 @@ app.on("ready", ()=>{
   });
 
   ipc.on("launch", ()=>{
-    return launcher.launch().then(()=>{
-      log.setUIWindow(null);
-      mainWindow.close();
-    });
+    return platform.killExplorer()
+      .then(launcher.launch)
+      .then(()=>{
+        log.setUIWindow(null);
+        mainWindow.close();
+      });
   });
 
   ipc.on("ui-pong", (event)=>{


### PR DESCRIPTION
Kill explorer.exe on Windows (except on 7) before starting Player, to avoid issues with touchscreen right swipe bringing up Action Center

@tejohnso @ahmedalsudani please review
