### PR TITLE
Continue installation on stop/start menu item err

### DIFF
--- a/installer/stop-start.js
+++ b/installer/stop-start.js
@@ -41,7 +41,7 @@ function createWindowsLinks() {
   .then(()=>{
     return platform.renameFile(startScriptShortcutTemp, startScriptShortcut);
   }).catch((err)=>{
-      return Promise.reject({message: "Error stop-start files", userFriendlyMessage: messages.stopStart, error: err});
+    log.external("error on stop-start file creation", require("util").inspect(err));
   });
 }
 
@@ -113,7 +113,7 @@ function createLinuxLinks() {
 
     return platform.writeTextFile(startScriptShortcut, shortcutContent);
   }).catch((err)=>{
-      return Promise.reject({message: "Error stop-start files", userFriendlyMessage: messages.stopStart, error: err});
+    log.external("error on stop-start file creation", require("util").inspect(err));
   });
 }
 

--- a/installer/ui/messages/stop-start.md
+++ b/installer/ui/messages/stop-start.md
@@ -1,4 +1,0 @@
-There was a problem creating the start player menu option on this display.
-
-Please get in touch with us at https://community.risevision.com
-


### PR DESCRIPTION
@fjvallarino I shouldn't have added a rejection for stop-start.  This will log the error but continue the install just like the uninstall.lnk failure.