### PR TITLE
Handle error on proxy file write error

### DIFF
--- a/installer/config.js
+++ b/installer/config.js
@@ -78,7 +78,10 @@ function saveProxySettings(fields) {
     displaySettingsString += `${key}=${displaySettings[key]}\n`;
   });
 
-  platform.writeTextFile(getDisplaySettingsFileName(), displaySettingsString); 
+  platform.writeTextFile(getDisplaySettingsFileName(), displaySettingsString)
+  .catch((err)=>{
+    log.external("error saving proxy settings", require("util").inspect(err));
+  });
 }
 
 function getDisplaySettingsFileName() {

--- a/package.json
+++ b/package.json
@@ -7,19 +7,19 @@
   "license": "ISC",
   "devDependencies": {
     "electron-mocha": "^0.8.0",
+    "electron-packager": "^5.2.1",
     "electron-prebuilt": "^0.36.7",
     "istanbul": "^0.4.0",
+    "jshint": "^2.9.1-rc2",
     "mocha": "^2.3.3",
     "mocha-junit-reporter": "^1.9.1",
     "simple-mock": "^0.4.1"
   },
   "dependencies": {
     "camelcase": "^2.1.0",
-    "electron-packager": "^5.2.0",
     "gunzip-maybe": "^1.2.1",
     "http-proxy-agent": "^1.0.0",
     "https-proxy-agent": "^1.0.0",
-    "jshint": "^2.9.1-rc2",
     "marked": "~0.3.5",
     "mkdirp": "^0.5.1",
     "ncp": "git://github.com/Rise-Vision/ncp.git",


### PR DESCRIPTION
@fjvallarino @ahmedalsudani write text file no longer handles errors from platform.js so this error handler is added here.