### PR TITLE
Don't reject from prereq check - return false

### DIFF
--- a/main.js
+++ b/main.js
@@ -105,7 +105,9 @@ app.on("ready", ()=>{
   ipc.on("set-proxy", (event, message)=>{
     proxy.setEndpoint(message);
     prereqCheck()
-    .then(()=>{
+    .then((passed)=>{
+      if (!passed) {return;}
+
       return installer.begin()
       .then(postInstall)
       .then(ui.enableContinue)
@@ -129,7 +131,9 @@ app.on("ready", ()=>{
     ui.disableContinue();
 
     prereqCheck()
-    .then(()=>{
+    .then((passed)=>{
+      if (!passed) {return;}
+
       return installer.begin()
       .then(postInstall)
       .then(ui.enableContinue)
@@ -151,16 +155,20 @@ app.on("ready", ()=>{
         ui.startUnattended();
 
         prereqCheck()
-        .then(installer.begin)
-        .then(postInstall)
-        .then(platform.killExplorer)
-        .then(launcher.launch)
-        .then(()=>{
-          mainWindow.close();
-        })
-        .catch((err)=>{
-          log.setUIWindow(null);
-          log.error(require("util").inspect(err), err.userFriendlyMessage || messages.unknown);
+        .then((passed)=>{
+          if (!passed) {return;}
+
+          installer.begin()
+          .then(postInstall)
+          .then(platform.killExplorer)
+          .then(launcher.launch)
+          .then(()=>{
+            mainWindow.close();
+          })
+          .catch((err)=>{
+            log.setUIWindow(null);
+            log.error(require("util").inspect(err), err.userFriendlyMessage || messages.unknown);
+          });
         });
       }
       else {
@@ -238,6 +246,12 @@ app.on("ready", ()=>{
         log.error("legacy watchdog", messages.legacyWatchdog);
         throw new Error();
       });
+    })
+    .then(()=>{
+      return true;
+    })
+    .catch(()=>{
+      return false;
     });
   }
 });


### PR DESCRIPTION
@ahmedalsudani @fjvallarino If the prereqs failed we were rejecting the promise.  That was triggering the new unhandled promise handler.   Instead the prereqs check will now return boolean pass/fail and on fail we don't run the install update or any further tasks, we just sit at whatever screen was showing (error or proxy).